### PR TITLE
Fix `svd(::Tensor)` function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OMEinsum = "ebe7aa44-baf0-506c-a96f-8464559b3922"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 ChainRulesCore = "1.15"

--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -34,8 +34,9 @@ Base.:*(a::Tensor, b::Tensor) = contract(a, b)
 Base.:*(a::Tensor, b) = contract(a, b)
 Base.:*(a, b::Tensor) = contract(a, b)
 
-function LinearAlgebra.svd(t::Tensor, left_inds=(); kwargs...)
+LinearAlgebra.svd(t::Tensor; left_inds=(), kwargs...) = svd(tensor, left_inds; kwargs...)
 
+function LinearAlgebra.svd(t::Tensor, left_inds; kwargs...)
     if isempty(left_inds)
         throw(ErrorException("no left-indices in SVD factorization"))
     elseif any(∉(labels(t)), left_inds)

--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -51,10 +51,6 @@ function LinearAlgebra.svd(t::Tensor, left_inds=(); kwargs...)
 
     # permute array
     tensor = permutedims(t, (left_inds..., right_inds...))
-    println(parent(tensor))
-    println(left_inds)
-    println(right_inds)
-
     data = reshape(parent(tensor), prod(i -> size(t, i), left_inds), prod(i -> size(t, i), right_inds))
 
     # compute SVD

--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -59,7 +59,7 @@ function LinearAlgebra.svd(t::Tensor, left_inds=(); kwargs...)
     # tensorify results
     U = reshape(U, size.((t,), left_inds)..., size(U, 2))
     s = Diagonal(s)
-    Vt = reshape(V', size.((t,), right_inds)..., size(Vt, 2))
+    Vt = reshape(V', size.((t,), right_inds)..., size(V, 2))
 
     vlind = Symbol(uuid4())
     vrind = Symbol(uuid4())

--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -54,12 +54,12 @@ function LinearAlgebra.svd(t::Tensor, left_inds=(); kwargs...)
     data = reshape(parent(tensor), prod(i -> size(t, i), left_inds), prod(i -> size(t, i), right_inds))
 
     # compute SVD
-    U, s, Vt = svd(data; kwargs...)
+    U, s, V = svd(data; kwargs...)
 
     # tensorify results
     U = reshape(U, size.((t,), left_inds)..., size(U, 2))
     s = Diagonal(s)
-    Vt = reshape(Vt', size.((t,), right_inds)..., size(Vt, 2))
+    Vt = reshape(V', size.((t,), right_inds)..., size(Vt, 2))
 
     vlind = Symbol(uuid4())
     vrind = Symbol(uuid4())

--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -59,7 +59,7 @@ function LinearAlgebra.svd(t::Tensor, left_inds=(); kwargs...)
     # tensorify results
     U = reshape(U, size.((t,), left_inds)..., size(U, 2))
     s = Diagonal(s)
-    Vt = reshape(Vt, size.((t,), right_inds)..., size(Vt, 2))
+    Vt = reshape(Vt', size.((t,), right_inds)..., size(Vt, 2))
 
     vlind = Symbol(uuid4())
     vrind = Symbol(uuid4())

--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -1,5 +1,6 @@
 using OMEinsum
 using LinearAlgebra
+using UUIDs: uuid4
 
 """
     contract(::Tensor, ::Tensor[, i])
@@ -33,8 +34,11 @@ Base.:*(a::Tensor, b::Tensor) = contract(a, b)
 Base.:*(a::Tensor, b) = contract(a, b)
 Base.:*(a, b::Tensor) = contract(a, b)
 
-function LinearAlgebra.svd(t::Tensor; left_inds=(), kwargs...)
-    if any(∉(labels(t)), left_inds)
+function LinearAlgebra.svd(t::Tensor, left_inds=(); kwargs...)
+
+    if isempty(left_inds)
+        throw(ErrorException("no left-indices in SVD factorization"))
+    elseif any(∉(labels(t)), left_inds)
         # TODO better error exception and checks
         throw(ErrorException("all left-indices must be in $(labels(t))"))
     end
@@ -47,6 +51,10 @@ function LinearAlgebra.svd(t::Tensor; left_inds=(), kwargs...)
 
     # permute array
     tensor = permutedims(t, (left_inds..., right_inds...))
+    println(parent(tensor))
+    println(left_inds)
+    println(right_inds)
+
     data = reshape(parent(tensor), prod(i -> size(t, i), left_inds), prod(i -> size(t, i), right_inds))
 
     # compute SVD

--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -34,7 +34,7 @@ Base.:*(a::Tensor, b::Tensor) = contract(a, b)
 Base.:*(a::Tensor, b) = contract(a, b)
 Base.:*(a, b::Tensor) = contract(a, b)
 
-LinearAlgebra.svd(t::Tensor; left_inds=(), kwargs...) = svd(tensor, left_inds; kwargs...)
+LinearAlgebra.svd(t::Tensor; left_inds=(), kwargs...) = svd(t, left_inds; kwargs...)
 
 function LinearAlgebra.svd(t::Tensor, left_inds; kwargs...)
     if isempty(left_inds)

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -1,0 +1,22 @@
+@testset "Numerics" begin
+    using Tensors: Tensor
+
+    @testset "svd" begin
+        using LinearAlgebra
+
+        data = rand(2, 2, 2)
+        tensor = Tensor(data, (:i, :j, :k))
+        # Throw exception if left_inds is not provided
+        @test_throws UndefVarError svd(tensor)
+        # Throw expcetion if left_inds ∉ labels(tensor)
+        @test_throws ErrorException svd(tensor, (:l,))
+
+        U, s, V = svd(tensor, labels(tensor)[1:2])
+        @test labels(U)[1:2] == labels(tensor)[1:2]
+        @test labels(U)[3] == labels(s)[1]
+        @test labels(V)[1] == labels(s)[2]
+        @test labels(V)[2] == labels(tensor)[3]
+
+        @test isapprox(U * s * V, data)
+    end
+end

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -7,7 +7,7 @@
         data = rand(2, 2, 2)
         tensor = Tensor(data, (:i, :j, :k))
         # Throw exception if left_inds is not provided
-        @test_throws UndefVarError svd(tensor)
+        @test_throws ErrorException svd(tensor)
         # Throw expcetion if left_inds ∉ labels(tensor)
         @test_throws ErrorException svd(tensor, (:l,))
 

--- a/test/Tensor_test.jl
+++ b/test/Tensor_test.jl
@@ -141,25 +141,6 @@
         @test all(x -> ==(x...), zip(tensor, data))
     end
 
-    @testset "svd" begin
-        using LinearAlgebra
-
-        data = rand(2, 2, 2)
-        tensor = Tensor(data, (:i, :j, :k))
-        # Throw exception if left_inds is not provided
-        @test_throws ErrorException svd(tensor)
-        # Throw expcetion if left_inds ∉ labels(tensor)
-        @test_throws ErrorException svd(tensor, (:l,))
-
-        U, s, Vt = svd(tensor, labels(tensor)[1:2])
-        @test labels(U)[1:2] == labels(tensor)[1:2]
-        @test labels(U)[3] == labels(s)[1]
-        @test labels(Vt)[1] == labels(s)[2]
-        @test labels(Vt)[2] == labels(tensor)[3]
-
-        @test isapprox(U * s * Vt, data)
-    end
-
     @testset "adjoint" begin
         @testset "Vector" begin
             data = rand(Complex{Float64}, 2)

--- a/test/Tensor_test.jl
+++ b/test/Tensor_test.jl
@@ -146,8 +146,10 @@
 
         data = rand(2, 2, 2)
         tensor = Tensor(data, (:i, :j, :k))
-        @test_throws ErrorException svd(tensor) # Throw exception if left_inds is not provided
-        @test_throws ErrorException svd(tensor, (:l,)) # Throw expcetion if left_inds ∉ labels(tensor)
+        # Throw exception if left_inds is not provided
+        @test_throws ErrorException svd(tensor)
+        # Throw expcetion if left_inds ∉ labels(tensor)
+        @test_throws ErrorException svd(tensor, (:l,))
 
         U, s, Vt = svd(tensor, labels(tensor)[1:2])
         @test labels(U)[1:2] == labels(tensor)[1:2]

--- a/test/Tensor_test.jl
+++ b/test/Tensor_test.jl
@@ -141,6 +141,23 @@
         @test all(x -> ==(x...), zip(tensor, data))
     end
 
+    @testset "svd" begin
+        using LinearAlgebra
+
+        data = rand(2, 2, 2)
+        tensor = Tensor(data, (:i, :j, :k))
+        @test_throws ErrorException svd(tensor) # Throw exception if left_inds is not provided
+        @test_throws ErrorException svd(tensor, (:l,)) # Throw expcetion if left_inds ∉ labels(tensor)
+
+        U, s, Vt = svd(tensor, labels(tensor)[1:2])
+        @test labels(U)[1:2] == labels(tensor)[1:2]
+        @test labels(U)[3] == labels(s)[1]
+        @test labels(Vt)[1] == labels(s)[2]
+        @test labels(Vt)[2] == labels(tensor)[3]
+
+        @test isapprox(U * s * Vt, data)
+    end
+
     @testset "adjoint" begin
         @testset "Vector" begin
             data = rand(Complex{Float64}, 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Tensors
     include("Tensor_test.jl")
     include("Metadata_test.jl")
     include("Differentiation_test.jl")
+    include("Numerics_test.jl")
 end
 
 if haskey(ENV, "ENABLE_AQUA_TESTS")


### PR DESCRIPTION
### Summary
This PR addresses the issue #14. We fixed the `svd` function by:

- Adding `UUIDs` as a dependency.
- Since in the code of `svd` for `Tensor` the `return` is `U, s, Vt`, we need to transpose the `V` returned from `LinearAlgebra.svd(::Matrix)`, since the output from this function is `U, S, V`.
- Throw an exception when `left_inds` is empty.

Moreover, we also added tests for this function inside `test/Tensor_test.jl`.

### Example
Now the function works as expected:
```julia
julia> using Tensors; using LinearAlgebra

julia> tensor = Tensor(rand(4, 4, 4), (:i, :j, :k))
4×4×4 Tensor{Float64, 3, Array{Float64, 3}}:
[:, :, 1] =
 0.265886  0.523771  0.68411   0.557354
 0.946131  0.953357  0.612342  0.129386
 0.686467  0.230194  0.95974   0.560487
 0.539693  0.796958  0.627144  0.445499

[:, :, 2] =
 0.424471   0.261525  0.430806  0.963923
 0.0495186  0.595677  0.689293  0.197853
 0.88456    0.215919  0.626647  0.870831
 0.658373   0.989261  0.44816   0.089124

[:, :, 3] =
 0.469228  0.7802    0.0633073  0.155388
 0.199996  0.786953  0.494671   0.589373
 0.990792  0.618157  0.995225   0.532068
 0.95642   0.743909  0.346406   0.0282854

[:, :, 4] =
 0.118724  0.132232  0.476907  0.639973
 0.344851  0.803019  0.15482   0.881199
 0.145761  0.638941  0.630639  0.39207
 0.922288  0.413967  0.346796  0.0747739

julia> U, s, Vt = svd(tensor, (labels(tensor)[1],))
([-0.41136774947294574 0.3285237943186542 -0.1617927054708116 -0.8346686838000298; -0.49368871484077637 -0.6082906674638946 -0.6093974073467864 0.12201932893688244; -0.5819195218388157 0.6123299097371797 -0.032831929061722706 0.5341758288974031; -0.4984151859998962 -0.3835448631960307 0.7754869340031044 -0.0556386149278667], [4.349270336334369 0.0 0.0 0.0; 0.0 1.3847049629783352 0.0 0.0; 0.0 0.0 1.2180035948585761 0.0; 0.0 0.0 0.0 0.9011826162635818], [-0.28623897955032207 -0.2798849009940078 -0.3344920913023078 -0.19344748271962636; -0.19847206870541725 -0.4134897019571987 0.14400483860822572 0.1998500861310857; -0.18357986196236048 -0.04535497664411593 -0.023819352039739897 0.12976442980960895; 0.25542647400992163 -0.2687857288515958 -0.020540541760536494 -0.19397450040983097;;; -0.23956815108732385 -0.23460760753293314 -0.25419051806841425 -0.24035731405993513; 0.2877540338257595 -0.3781595833353755 -0.04761657640236018 0.502181030841088; 0.31417396940088055 0.29125789734005153 -0.1336501247121248 -0.193762404308362; 0.09723801206728645 -0.09465881203021123 0.03809612863846666 -0.3553066192618149;;; -0.3092511040118255 -0.3310790158145634 -0.23499371872225788 -0.15602781879618818; 0.19669082180906675 -0.09329669285977298 0.1418629602927178 0.005409928092364175; 0.41984005597367324 -0.04039527298903642 -0.062179913856142 -0.3118520668535868; 0.1207263367813399 -0.2955789192050101 0.5768759779809406 0.24951806814624153;;; -0.17556783329126052 -0.23658601770456483 -0.18680062920843613 -0.22158281428496956; -0.3143277136596712 -0.1535057513555896 0.22795230725505986 -0.08260370784373704; 0.3949712713004979 -0.1729907535716515 0.0629912716085238 -0.48885684038211397; -0.0338107186684877 0.33942990801310396 -0.06834555514200906 -0.24564211578834122])

julia> isapprox(U * s * Vt, tensor)
true
```