### PR TITLE
Fix `svd` function

### DIFF
--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -58,9 +58,9 @@ function LinearAlgebra.svd(t::Tensor, left_inds; kwargs...)
     U, s, V = svd(data; kwargs...)
 
     # tensorify results
-    U = reshape(U, size.((t,), left_inds)..., size(U, 2))
+    U = reshape(U, ([size(t, ind) for ind in left_inds]..., size(U, 2)))
     s = Diagonal(s)
-    Vt = reshape(V', size.((t,), right_inds)..., size(V, 2))
+    Vt = reshape(V', (size(V', 1), [size(t, ind) for ind in right_inds]...))
 
     vlind = Symbol(uuid4())
     vrind = Symbol(uuid4())

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -6,17 +6,40 @@
 
         data = rand(2, 2, 2)
         tensor = Tensor(data, (:i, :j, :k))
-        # Throw exception if left_inds is not provided
-        @test_throws ErrorException svd(tensor)
-        # Throw expcetion if left_inds ∉ labels(tensor)
-        @test_throws ErrorException svd(tensor, (:l,))
 
-        U, s, V = svd(tensor, labels(tensor)[1:2])
-        @test labels(U)[1:2] == labels(tensor)[1:2]
-        @test labels(U)[3] == labels(s)[1]
-        @test labels(V)[1] == labels(s)[2]
-        @test labels(V)[2] == labels(tensor)[3]
+        @testset "Error Handling Test" begin
+            # Throw exception if left_inds is not provided
+            @test_throws ErrorException svd(tensor)
+            # Throw exception if left_inds ∉ labels(tensor)
+            @test_throws ErrorException svd(tensor, (:l,))
+        end
 
-        @test isapprox(U * s * V, data)
+        @testset "Labels Test" begin
+            U, s, V = svd(tensor, labels(tensor)[1:2])
+            @test labels(U)[1:2] == labels(tensor)[1:2]
+            @test labels(U)[3] == labels(s)[1]
+            @test labels(V)[1] == labels(s)[2]
+            @test labels(V)[2] == labels(tensor)[3]
+        end
+
+        @testset "Size Test" begin
+            U, s, V = svd(tensor, labels(tensor)[1:2])
+            @test size(U) == (2, 2, 2)
+            @test size(s) == (2, 2)
+            @test size(V) == (2, 2)
+
+            # Additional test with different dimensions
+            data2 = rand(2, 4, 6, 8)
+            tensor2 = Tensor(data2, (:i, :j, :k, :l))
+            U2, s2, V2 = svd(tensor2, labels(tensor2)[1:2])
+            @test size(U2) == (2, 4, 8)
+            @test size(s2) == (8, 8)
+            @test size(V2) == (8, 6, 8)
+        end
+
+        @testset "Accuracy Test" begin
+            U, s, V = svd(tensor, labels(tensor)[1:2])
+            @test isapprox(U * s * V, data)
+        end
     end
 end

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -39,7 +39,12 @@
 
         @testset "Accuracy Test" begin
             U, s, V = svd(tensor, labels(tensor)[1:2])
-            @test isapprox(U * s * V, data)
+            @test U * s * V ≈ tensor
+
+            data2 = rand(2, 4, 6, 8)
+            tensor2 = Tensor(data2, (:i, :j, :k, :l))
+            U2, s2, V2 = svd(tensor2, labels(tensor2)[1:2])
+            @test U2 * s2 * V2 ≈ tensor2
         end
     end
 end


### PR DESCRIPTION
### Summary
This PR addresses an issue with the custom `svd` function for a `Tensor`. The issue was related to the incorrect reshaping of the resulting `U` and `V` matrices, sometimes leading to incorrect output sizes. The function has been fixed, and new test cases have been added to cover the previous error.

### Issue
The original `svd` function did not correctly reshape the resulting `U` and `V` matrices. The problem occurred when the indices of the `Tensor` had different dimensions. The original code used the following lines to reshape the tensors:
```julia
U = reshape(U, size.((t,), left_inds)..., size(U, 2))
Vt = reshape(V', size.((t,), right_inds)..., size(V, 2))
```
This caused issues for the `Vt` tensor because the `vrind` was expected to be its first index but was assigned as the last index in the original code.

### Example
Here's an example where the original code failed:
```julia
julia> using Tensors

julia> using LinearAlgebra

julia> data = rand(2, 4, 6, 8)
2×4×6×8 Array{Float64, 4}

julia> tensor = Tensor(data, (:i, :j, :k, :l))
2×4×6×8 Tensor{Float64, 4, Array{Float64, 4}}

julia> U, s, V = svd(tensor, labels(tensor)[1:2])

julia> size(U)
(2, 4, 8)

julia> labels(U) # This is OK
(:i, :j, Symbol("5597b37d-a1d6-48a6-9ea7-15047defd0cf"))

julia> size(V)
(6, 8, 8)

julia> labels(V) # This is wrong, label :k should have size 6
(Symbol("436e0761-67dc-4886-aecf-0a2d9abe6a30"), :k, :l)
```