### PR TITLE
Implement `transpose` method for 1- and 2-D `Tensor`s

### DIFF
--- a/src/Tensor.jl
+++ b/src/Tensor.jl
@@ -154,6 +154,7 @@ end
 
 Base.adjoint(t::Tensor) = Tensor(conj(parent(t)), labels(t); t.meta...)
 
+# NOTE: Maybe use transpose for lazy transposition ?
 Base.transpose(t::Tensor{T,1,A}) where {T, A<:AbstractArray{T, 1}} =
     permutedims(t, (1,))
 

--- a/src/Tensor.jl
+++ b/src/Tensor.jl
@@ -153,3 +153,9 @@ function Base.view(t::Tensor, inds::Pair{Symbol,<:Any}...)
 end
 
 Base.adjoint(t::Tensor) = Tensor(conj(parent(t)), labels(t); t.meta...)
+
+Base.transpose(t::Tensor{T,1,A}) where {T, A<:AbstractArray{T, 1}} =
+    permutedims(t, (1,))
+
+Base.transpose(t::Tensor{T,2,A}) where {T, A<:AbstractArray{T, 2}} =
+    permutedims(t, (2, 1))

--- a/test/Tensor_test.jl
+++ b/test/Tensor_test.jl
@@ -166,4 +166,30 @@
             @test isapprox(only(tensor' * tensor), tr(data' * data))
         end
     end
+
+    @testset "transpose" begin
+        @testset "Vector" begin
+            data = rand(Complex{Float64}, 2)
+            tensor = Tensor(data, (:i,); test="TEST")
+
+            @test transpose(tensor) |> labels == labels(tensor)
+            @test transpose(tensor) |> ndims == 1
+            @test transpose(tensor).meta == tensor.meta
+
+            @test isapprox(only(transpose(tensor) * tensor), transpose(data) * data)
+        end
+
+        @testset "Matrix" begin
+            using LinearAlgebra: tr
+
+            data = rand(Complex{Float64}, 2, 2)
+            tensor = Tensor(data, (:i, :j); test="TEST")
+
+            @test transpose(tensor) |> labels == (:j, :i)
+            @test transpose(tensor) |> ndims == 2
+            @test transpose(tensor).meta == tensor.meta
+
+            @test isapprox(only(transpose(tensor) * tensor), tr(transpose(data) * data))
+        end
+    end
 end


### PR DESCRIPTION
### Summary
This PR adds a `transpose` function for 1- and 2-dimensional `Tensor` objects. Previously, the transpose operation was not defined for `Tensor`s, leading to issues when contracting tensors in the `Tenet` module.

The new `transpose` method ensures that the transpose operation is correctly applied to both 1- and 2-dimensional `Tensor`s by calling `permutedims`, so a 1d `Tensor` is kept as the same with the `transpose` but in a 2d `Tensor` the `data` field will be transposed and the `labels` permuted. We have also added tests to cover for this new function. 

This resolves the issues encountered in `Tenet` when contracting tensor networks, as an example:
```julia
julia> using Tenet

julia> ψ = rand(MatrixProductState{Open}, 16, 2, 8)
TensorNetwork{MatrixProductState{Open}}(#tensors=16, #inds=31)

julia> contract(ψ, ψ')
ERROR: MethodError: *(::Tensor{Float64, 2, Matrix{Float64}}, ::LinearAlgebra.Transpose{Float64, Tensor{Float64, 2, Matrix{Float64}}}) is ambiguous. Candidates:
  *(A::AbstractMatrix, B::AbstractMatrix) in LinearAlgebra at /opt/julia-1.8.2/share/julia/stdlib/v1.8/LinearAlgebra/src/matmul.jl:139
  *(a::Tensor, b) in Tensors at /home/jofrevalles/.julia/packages/Tensors/qaAgZ/src/Numerics.jl:34
Possible fix, define
  *(::Tensor{T, 2, A} where {T, A<:AbstractMatrix{T}}, ::AbstractMatrix)
Stacktrace: ...
```

With the new `transpose` defined:
```julia
julia> using Tenet

julia> ψ = rand(MatrixProductState{Open}, 16, 2, 8)
TensorNetwork{MatrixProductState{Open}}(#tensors=16, #inds=31)

julia> contract(ψ, ψ')
0-dimensional Tensor{Float64, 0, Array{Float64, 0}}:
0.9999999999999992
```
