### PR TITLE
Add `truncatedims` function

### DIFF
--- a/src/Tensor.jl
+++ b/src/Tensor.jl
@@ -160,3 +160,14 @@ Base.transpose(t::Tensor{T,1,A}) where {T, A<:AbstractArray{T, 1}} =
 
 Base.transpose(t::Tensor{T,2,A}) where {T, A<:AbstractArray{T, 2}} =
     permutedims(t, (2, 1))
+
+function truncatedims(t::Tensor, dim::Union{Integer, Symbol}, end_ind::Integer)
+    if dim isa Symbol
+        dim = findfirst(==(dim), labels(t))
+    end
+
+    data = view(parent(t), ntuple(i -> i == dim ? (1:end_ind) : Colon(), ndims(t))...)
+    new_labels = labels(t)
+
+    return Tensor(data, new_labels; t.meta...)
+end

--- a/src/Tensors.jl
+++ b/src/Tensors.jl
@@ -2,7 +2,7 @@ module Tensors
 
 include("Tensor.jl")
 export Tensor
-export labels, dim
+export labels, dim, truncatedims
 
 include("Metadata.jl")
 export tags, hastag, tag!, untag!

--- a/test/Tensor_test.jl
+++ b/test/Tensor_test.jl
@@ -133,6 +133,21 @@
         end
     end
 
+    @testset "truncatedims" begin
+        data = rand(4, 4, 4)
+        tensor = Tensor(data, (:i, :j, :k))
+
+        truncated_tensor_1 = truncatedims(tensor, :j, 2)
+        @test truncated_tensor_1.labels == tensor.labels
+        @test size(truncated_tensor_1) == (4, 2, 4)
+
+        truncated_tensor_2 = truncatedims(tensor, 3, 3)
+        @test truncated_tensor_2.labels == tensor.labels
+        @test size(truncated_tensor_2) == (4, 4, 3)
+
+        @test_throws BoundsError truncatedims(tensor, :j, 5)
+    end
+
     @testset "iteration" begin
         data = rand(2, 2, 2)
         tensor = Tensor(data, (:i, :j, :k))


### PR DESCRIPTION
### Summary
This PR addresses issue #19 (resolve #19) by adding a new function `truncatedims`, which truncates the specified dimension of a `Tensor`. The original issue suggested an in-place version of the function (`truncatedims!`). However, after discussion, it was concluded that modifying the `data` field of a `Tensor` in-place is not possible due to potential differences in the shape of the original and truncated data arrays. Instead, we provide a non-mutating version that returns a new `Tensor` with the desired truncated dimensions.

This PR also includes tests for the new `truncatedims` function.

### Example usage
Basic usage of the `truncatedims` function:
```julia
julia> using Tensors

julia> U = Tensor(rand(4, 4), (:i, :j))
4×4 Tensor{Float64, 2, Matrix{Float64}}:
 0.571572  0.978876  0.723208   0.816936
 0.102065  0.293091  0.756039   0.517619
 0.435616  0.960413  0.566463   0.737394
 0.966591  0.490533  0.0677257  0.835814

julia> V = truncatedims(U, :j, 2)
4×2 Tensor{Float64, 2, SubArray{Float64, 2, Matrix{Float64}, Tuple{Base.Slice{Base.OneTo{Int64}}, UnitRange{Int64}}, true}}:
 0.571572  0.978876
 0.102065  0.293091
 0.435616  0.960413
 0.966591  0.490533
```