### PR TITLE
Fix `replace` function to allow replacement in `meta[:alias]`

### DIFF
--- a/src/Tensor.jl
+++ b/src/Tensor.jl
@@ -57,7 +57,7 @@ labels(t::Tensor) = t.labels
 function Base.replace(t::Tensor, old_new::Pair{Symbol,Symbol}...)
     new_labels = replace(labels(t), old_new...)
     new_meta = deepcopy(t.meta)
-    old_new_dict = Dict{Symbol, Symbol}(old_new)
+    old_new_dict = Base.ImmutableDict(old_new...)
 
     haskey(new_meta, :alias) && map!(values(new_meta[:alias])) do i
         get(old_new_dict, i, i)

--- a/src/Tensor.jl
+++ b/src/Tensor.jl
@@ -59,14 +59,8 @@ function Base.replace(t::Tensor, old_new::Pair{Symbol,Symbol}...)
     new_meta = deepcopy(t.meta)
 
     if haskey(new_meta, :alias)
-        full_mapping = Dict{Symbol, Symbol}(old_new)
-
-        updated_aliases = Dict{Symbol, Symbol}()
-        for (key, value) in new_meta[:alias]
-            updated_value = value in keys(full_mapping) ? full_mapping[value] : value
-            updated_aliases[key] = updated_value
-        end
-        new_meta[:alias] = updated_aliases
+        old_new_dict = Dict{Symbol, Symbol}(old_new)
+        new_meta[:alias] = Dict(k => get(old_new_dict, v, v) for (k, v) in new_meta[:alias])
     end
 
     return Tensor(parent(t), new_labels; new_meta...)

--- a/src/Tensor.jl
+++ b/src/Tensor.jl
@@ -69,7 +69,7 @@ function Base.replace(t::Tensor, old_new::Pair{Symbol,Symbol}...)
         new_meta[:alias] = updated_aliases
     end
 
-    return Tensor(parent(t), new_labels; copy(new_meta)...)
+    return Tensor(parent(t), new_labels; new_meta...)
 end
 
 Base.parent(t::Tensor) = t.data

--- a/src/Tensor.jl
+++ b/src/Tensor.jl
@@ -57,10 +57,10 @@ labels(t::Tensor) = t.labels
 function Base.replace(t::Tensor, old_new::Pair{Symbol,Symbol}...)
     new_labels = replace(labels(t), old_new...)
     new_meta = deepcopy(t.meta)
+    old_new_dict = Dict{Symbol, Symbol}(old_new)
 
-    if haskey(new_meta, :alias)
-        old_new_dict = Dict{Symbol, Symbol}(old_new)
-        new_meta[:alias] = Dict(k => get(old_new_dict, v, v) for (k, v) in new_meta[:alias])
+    haskey(new_meta, :alias) && map!(values(new_meta[:alias])) do i
+        get(old_new_dict, i, i)
     end
 
     return Tensor(parent(t), new_labels; new_meta...)

--- a/test/Tensor_test.jl
+++ b/test/Tensor_test.jl
@@ -42,12 +42,21 @@
     end
 
     @testset "Base.replace" begin
+        # no :alias in meta
         tensor = Tensor(zeros(2, 2, 2), (:i, :j, :k))
         @test labels(replace(tensor, :i => :u, :j => :v, :k => :w)) == (:u, :v, :w)
         @test parent(replace(tensor, :i => :u, :j => :v, :k => :w)) === parent(tensor)
 
         @test labels(replace(tensor, :a => :u, :b => :v, :c => :w)) == (:i, :j, :k)
         @test parent(replace(tensor, :a => :u, :b => :v, :c => :w)) === parent(tensor)
+
+        # :alias in meta
+        tensor = Tensor(zeros(2, 2, 2), (:i, :j, :k); alias=Dict(:left => :i, :right => :j, :up => :k))
+
+        replaced_tensor = replace(tensor, :i => :u, :j => :v, :k => :w)
+        @test labels(replaced_tensor) == (:u, :v, :w)
+        @test parent(replaced_tensor) === parent(tensor)
+        @test replaced_tensor.meta[:alias] == Dict(:left => :u, :right => :v, :up => :w)
     end
 
     @testset "dim" begin


### PR DESCRIPTION
### Summary
This PR fixes the `replace` function to support label replacements in the `meta[:alias]` dictionary. In the current implementation, the labels are replaced in the `labels` field but the `meta[:alias]` `Dict` is left unchanged.

Additionally, we added tests to cover for the new implementation.

### Example
Here we can see that this PR solves the issue:
```julia
julia> A = Tensor(rand(2,2,2,2), (:i, :j, :k, :l); alias=Dict(:left => :i, :right => :j, :up => :k, :down => :l))
2×2×2×2 Tensor{Float64, 4, Array{Float64, 4}}:
...

julia> B  = replace(A, :j => :p)
2×2×2×2 Tensor{Float64, 4, Array{Float64, 4}}:
...

julia> B.meta[:alias]
Dict{Symbol, Symbol} with 4 entries:
  :left  => :i
  :right => :p
  :up    => :k
  :down  => :l

julia> labels(B)
(:i, :p, :k, :l)

```