### PR TITLE
Add `qr` decomposition for `Tensor`s

### DIFF
--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -100,7 +100,6 @@ function LinearAlgebra.qr(t::Tensor, left_inds; kwargs...)
     R = reshape(R, (size(R, 1), [size(t, ind) for ind in right_inds]...))
 
     qlind = Symbol(uuid4())
-    rlind = Symbol(uuid4())
 
     Q = Tensor(Q, (left_inds..., qlind))
     R = Tensor(R, (qlind, right_inds...))

--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -75,18 +75,12 @@ end
 LinearAlgebra.qr(t::Tensor; left_inds=(), kwargs...) = qr(t, left_inds; kwargs...)
 
 function LinearAlgebra.qr(t::Tensor, left_inds; kwargs...)
-    if isempty(left_inds)
-        throw(ErrorException("no left-indices in QR factorization"))
-    elseif any(∉(labels(t)), left_inds)
-        # TODO better error exception and checks
-        throw(ErrorException("all left-indices must be in $(labels(t))"))
-    end
+    # TODO better error exception and checks
+    isempty(left_inds) && throw(ErrorException("no left-indices in QR factorization"))
+    left_inds ⊆ labels(t) || throw(ErrorException("all left-indices must be in $(labels(t))"))
 
     right_inds = setdiff(labels(t), left_inds)
-    if isempty(right_inds)
-        # TODO better error exception and checks
-        throw(ErrorException("no right-indices in QR factorization"))
-    end
+    isempty(right_inds) && throw(ErrorException("no right-indices in QR factorization"))
 
     # permute array
     tensor = permutedims(t, (left_inds..., right_inds...))

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -162,7 +162,7 @@
 
         @testset "Accuracy Test" begin
             Q, R = qr(tensor, labels(tensor)[1:2])
-            Q_truncated = truncatedims(Q, labels(Q)[end], 2)
+            Q_truncated = view(Q, labels(Q)[end] => 1:2)
             tensor_recovered = ein"ijk, kl -> ijl"(Q_truncated, R)
             @test tensor_recovered ≈ tensor
 

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -132,21 +132,23 @@
         data = rand(2, 2, 2)
         tensor = Tensor(data, (:i, :j, :k))
 
-        @testset "Error Handling Test" begin
+        @testset "[exceptions]" begin
             # Throw exception if left_inds is not provided
             @test_throws ErrorException qr(tensor)
             # Throw exception if left_inds ∉ labels(tensor)
             @test_throws ErrorException qr(tensor, (:l,))
+            # throw exception if no right-inds
+            @test_throws ErrorException qr(tensor, (:i,:j,:k))
         end
 
-        @testset "Labels Test" begin
+        @testset "labels" begin
             Q, R = qr(tensor, labels(tensor)[1:2])
             @test labels(Q)[1:2] == labels(tensor)[1:2]
             @test labels(Q)[3] == labels(R)[1]
             @test labels(R)[2] == labels(tensor)[3]
         end
 
-        @testset "Size Test" begin
+        @testset "size" begin
             Q, R = qr(tensor, labels(tensor)[1:2])
             # Q's new index size = min(prod(left_inds), prod(right_inds)).
             @test size(Q) == (2, 2, 4)
@@ -160,7 +162,7 @@
             @test size(R2) == (8, 6, 8)
         end
 
-        @testset "Accuracy Test" begin
+        @testset "[accuracy]" begin
             Q, R = qr(tensor, labels(tensor)[1:2])
             Q_truncated = view(Q, labels(Q)[end] => 1:2)
             tensor_recovered = ein"ijk, kl -> ijl"(Q_truncated, R)

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -126,5 +126,50 @@
                 @test C ≈ C_ein
             end
         end
+
+        @testset "qr" begin
+            data = rand(2, 2, 2)
+            tensor = Tensor(data, (:i, :j, :k))
+
+            @testset "Error Handling Test" begin
+                # Throw exception if left_inds is not provided
+                @test_throws ErrorException qr(tensor)
+                # Throw exception if left_inds ∉ labels(tensor)
+                @test_throws ErrorException qr(tensor, (:l,))
+            end
+
+            @testset "Labels Test" begin
+                Q, R = qr(tensor, labels(tensor)[1:2])
+                @test labels(Q)[1:2] == labels(tensor)[1:2]
+                @test labels(Q)[3] == labels(R)[1]
+                @test labels(R)[2] == labels(tensor)[3]
+            end
+
+            @testset "Size Test" begin
+                Q, R = qr(tensor, labels(tensor)[1:2])
+                # Q's new index size = min(prod(left_inds), prod(right_inds)).
+                @test size(Q) == (2, 2, 4)
+                @test size(R) == (2, 2)
+
+                # Additional test with different dimensions
+                data2 = rand(2, 4, 6, 8)
+                tensor2 = Tensor(data2, (:i, :j, :k, :l))
+                Q2, R2 = qr(tensor2, labels(tensor2)[1:2])
+                @test size(Q2) == (2, 4, 8)
+                @test size(R2) == (8, 6, 8)
+            end
+
+            @testset "Accuracy Test" begin
+                Q, R = qr(tensor, labels(tensor)[1:2])
+                Q_truncated = truncatedims(Q, labels(Q)[end], 2)
+                tensor_recovered = ein"ijk, kl -> ijl"(Q_truncated, R)
+                @test tensor_recovered ≈ tensor
+
+                data2 = rand(2, 4, 6, 8)
+                tensor2 = Tensor(data2, (:i, :j, :k, :l))
+                Q2, R2 = qr(tensor2, labels(tensor2)[1:2])
+                tensor2_recovered = ein"ijk, klm -> ijlm"(Q2, R2)
+                @test tensor2_recovered ≈ tensor2
+            end
     end
 end

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -171,5 +171,6 @@
                 tensor2_recovered = ein"ijk, klm -> ijlm"(Q2, R2)
                 @test tensor2_recovered ≈ tensor2
             end
+        end
     end
 end

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -126,51 +126,51 @@
                 @test C ≈ C_ein
             end
         end
+    end
 
-        @testset "qr" begin
-            data = rand(2, 2, 2)
-            tensor = Tensor(data, (:i, :j, :k))
+    @testset "qr" begin
+        data = rand(2, 2, 2)
+        tensor = Tensor(data, (:i, :j, :k))
 
-            @testset "Error Handling Test" begin
-                # Throw exception if left_inds is not provided
-                @test_throws ErrorException qr(tensor)
-                # Throw exception if left_inds ∉ labels(tensor)
-                @test_throws ErrorException qr(tensor, (:l,))
-            end
+        @testset "Error Handling Test" begin
+            # Throw exception if left_inds is not provided
+            @test_throws ErrorException qr(tensor)
+            # Throw exception if left_inds ∉ labels(tensor)
+            @test_throws ErrorException qr(tensor, (:l,))
+        end
 
-            @testset "Labels Test" begin
-                Q, R = qr(tensor, labels(tensor)[1:2])
-                @test labels(Q)[1:2] == labels(tensor)[1:2]
-                @test labels(Q)[3] == labels(R)[1]
-                @test labels(R)[2] == labels(tensor)[3]
-            end
+        @testset "Labels Test" begin
+            Q, R = qr(tensor, labels(tensor)[1:2])
+            @test labels(Q)[1:2] == labels(tensor)[1:2]
+            @test labels(Q)[3] == labels(R)[1]
+            @test labels(R)[2] == labels(tensor)[3]
+        end
 
-            @testset "Size Test" begin
-                Q, R = qr(tensor, labels(tensor)[1:2])
-                # Q's new index size = min(prod(left_inds), prod(right_inds)).
-                @test size(Q) == (2, 2, 4)
-                @test size(R) == (2, 2)
+        @testset "Size Test" begin
+            Q, R = qr(tensor, labels(tensor)[1:2])
+            # Q's new index size = min(prod(left_inds), prod(right_inds)).
+            @test size(Q) == (2, 2, 4)
+            @test size(R) == (2, 2)
 
-                # Additional test with different dimensions
-                data2 = rand(2, 4, 6, 8)
-                tensor2 = Tensor(data2, (:i, :j, :k, :l))
-                Q2, R2 = qr(tensor2, labels(tensor2)[1:2])
-                @test size(Q2) == (2, 4, 8)
-                @test size(R2) == (8, 6, 8)
-            end
+            # Additional test with different dimensions
+            data2 = rand(2, 4, 6, 8)
+            tensor2 = Tensor(data2, (:i, :j, :k, :l))
+            Q2, R2 = qr(tensor2, labels(tensor2)[1:2])
+            @test size(Q2) == (2, 4, 8)
+            @test size(R2) == (8, 6, 8)
+        end
 
-            @testset "Accuracy Test" begin
-                Q, R = qr(tensor, labels(tensor)[1:2])
-                Q_truncated = truncatedims(Q, labels(Q)[end], 2)
-                tensor_recovered = ein"ijk, kl -> ijl"(Q_truncated, R)
-                @test tensor_recovered ≈ tensor
+        @testset "Accuracy Test" begin
+            Q, R = qr(tensor, labels(tensor)[1:2])
+            Q_truncated = truncatedims(Q, labels(Q)[end], 2)
+            tensor_recovered = ein"ijk, kl -> ijl"(Q_truncated, R)
+            @test tensor_recovered ≈ tensor
 
-                data2 = rand(2, 4, 6, 8)
-                tensor2 = Tensor(data2, (:i, :j, :k, :l))
-                Q2, R2 = qr(tensor2, labels(tensor2)[1:2])
-                tensor2_recovered = ein"ijk, klm -> ijlm"(Q2, R2)
-                @test tensor2_recovered ≈ tensor2
-            end
+            data2 = rand(2, 4, 6, 8)
+            tensor2 = Tensor(data2, (:i, :j, :k, :l))
+            Q2, R2 = qr(tensor2, labels(tensor2)[1:2])
+            tensor2_recovered = ein"ijk, klm -> ijlm"(Q2, R2)
+            @test tensor2_recovered ≈ tensor2
         end
     end
 end


### PR DESCRIPTION
### Summary
This pull request addresses issue "Implement QR factorization" (resolve #2) by adding the `qr` function for `Tensor`s, based on the full QR decomposition provided by the `LinearAlgebra` library. The implementation includes the necessary error handling and dimension reshaping to work seamlessly with Tensors. In addition, tests have been added to ensure the accuracy and correctness of the new function.

### Example
```julia
julia> using Tensors
julia> using OMEinsum
julia> using LinearAlgebra
julia> using Test

julia> data = rand(2, 4, 6, 8)
2×4×6×8 Array{Float64, 4}:
...

julia> tensor = Tensor(data, (:i, :j, :k, :l))
2×4×6×8 Tensor{Float64, 4, Array{Float64, 4}}:
...

julia> Q, R = qr(tensor, labels(tensor)[1:2])
...

julia> tensor_recovered = ein"ijk,klm->ijlm"(Q, R)
2×4×6×8 Array{Float64, 4}:
...

julia> @test tensor_recovered ≈ tensor
Test Passed
```