### PR TITLE
Add `LU` decomposition for `Tensor`s

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tensors"
 uuid = "a57d67a0-4683-47ff-be60-6114e830558b"
 authors = ["Sergio Sánchez Ramírez <sergio.sanchez.ramirez@bsc.es>"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -100,7 +100,6 @@ function LinearAlgebra.qr(t::Tensor, left_inds; kwargs...)
     R = reshape(R, (size(R, 1), [size(t, ind) for ind in right_inds]...))
 
     qlind = Symbol(uuid4())
-    rlind = Symbol(uuid4())
 
     Q = Tensor(Q, (left_inds..., qlind))
     R = Tensor(R, (qlind, right_inds...))

--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -75,18 +75,12 @@ end
 LinearAlgebra.qr(t::Tensor; left_inds=(), kwargs...) = qr(t, left_inds; kwargs...)
 
 function LinearAlgebra.qr(t::Tensor, left_inds; kwargs...)
-    if isempty(left_inds)
-        throw(ErrorException("no left-indices in QR factorization"))
-    elseif any(∉(labels(t)), left_inds)
-        # TODO better error exception and checks
-        throw(ErrorException("all left-indices must be in $(labels(t))"))
-    end
+    # TODO better error exception and checks
+    isempty(left_inds) && throw(ErrorException("no left-indices in QR factorization"))
+    left_inds ⊆ labels(t) || throw(ErrorException("all left-indices must be in $(labels(t))"))
 
     right_inds = setdiff(labels(t), left_inds)
-    if isempty(right_inds)
-        # TODO better error exception and checks
-        throw(ErrorException("no right-indices in QR factorization"))
-    end
+    isempty(right_inds) && throw(ErrorException("no right-indices in QR factorization"))
 
     # permute array
     tensor = permutedims(t, (left_inds..., right_inds...))

--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -100,3 +100,39 @@ function LinearAlgebra.qr(t::Tensor, left_inds; kwargs...)
 
     return Q, R
 end
+
+LinearAlgebra.lu(t::Tensor; left_inds=(), kwargs...) = lu(t, left_inds; kwargs...)
+
+function LinearAlgebra.lu(t::Tensor, left_inds; kwargs...)
+    # TODO better error exception and checks
+    isempty(left_inds) && throw(ErrorException("no left-indices in LU factorization"))
+    left_inds ⊆ labels(t) || throw(ErrorException("all left-indices must be in $(labels(t))"))
+
+    right_inds = setdiff(labels(t), left_inds)
+    isempty(right_inds) && throw(ErrorException("no right-indices in LU factorization"))
+
+    # permute array
+    tensor = permutedims(t, (left_inds..., right_inds...))
+    data = reshape(parent(tensor), prod(i -> size(t, i), left_inds), prod(i -> size(t, i), right_inds))
+
+    # compute LU
+    L, U, p = lu(data; kwargs...)
+
+    # build permutation matrix
+    P = Matrix{eltype(data)}(I, size(L, 1), size(L, 1))
+    P = P[invperm(p), :]
+
+    # tensorify results
+    L = reshape(L, ([size(t, ind) for ind in left_inds]..., size(L, 2)))
+    U = reshape(U, (size(U, 1), [size(t, ind) for ind in right_inds]...))
+    P = reshape(P, (append!([size(t, ind) for ind in left_inds], [size(t, ind) for ind in left_inds])...))
+
+    shared_inds_PL = (Symbol(uuid4()), Symbol(uuid4()))
+    shared_inds_LU = Symbol(uuid4())
+
+    P = Tensor(P, (left_inds..., shared_inds_PL...))
+    L = Tensor(L, (shared_inds_PL..., shared_inds_LU))
+    U = Tensor(U, (shared_inds_LU, right_inds...))
+
+    return P, L, U
+end

--- a/src/Tensor.jl
+++ b/src/Tensor.jl
@@ -165,8 +165,8 @@ end
 Base.adjoint(t::Tensor) = Tensor(conj(parent(t)), labels(t); t.meta...)
 
 # NOTE: Maybe use transpose for lazy transposition ?
-Base.transpose(t::Tensor{T,1,A}) where {T, A<:AbstractArray{T, 1}} =
+Base.transpose(t::Tensor{T,1,A}) where {T,A<:AbstractArray{T,1}} =
     permutedims(t, (1,))
 
-Base.transpose(t::Tensor{T,2,A}) where {T, A<:AbstractArray{T, 2}} =
+Base.transpose(t::Tensor{T,2,A}) where {T,A<:AbstractArray{T,2}} =
     permutedims(t, (2, 1))

--- a/src/Tensor.jl
+++ b/src/Tensor.jl
@@ -8,7 +8,7 @@ struct Tensor{T,N,A<:AbstractArray{T,N}} <: AbstractArray{T,N}
 
     function Tensor{T,N,A}(data::A, labels::NTuple{N,Symbol}; meta...) where {T,N,A<:AbstractArray{T,N}}
         meta = Dict{Symbol,Any}(meta...)
-        !haskey(meta, :tags) && (meta[:tags] = Set{String}())
+        haskey(meta, :tags) || (meta[:tags] = Set{String}())
 
         new{T,N,A}(data, labels, meta)
     end

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -162,7 +162,7 @@
 
         @testset "Accuracy Test" begin
             Q, R = qr(tensor, labels(tensor)[1:2])
-            Q_truncated = truncatedims(Q, labels(Q)[end], 2)
+            Q_truncated = view(Q, labels(Q)[end] => 1:2)
             tensor_recovered = ein"ijk, kl -> ijl"(Q_truncated, R)
             @test tensor_recovered ≈ tensor
 

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -132,21 +132,23 @@
         data = rand(2, 2, 2)
         tensor = Tensor(data, (:i, :j, :k))
 
-        @testset "Error Handling Test" begin
+        @testset "[exceptions]" begin
             # Throw exception if left_inds is not provided
             @test_throws ErrorException qr(tensor)
             # Throw exception if left_inds ∉ labels(tensor)
             @test_throws ErrorException qr(tensor, (:l,))
+            # throw exception if no right-inds
+            @test_throws ErrorException qr(tensor, (:i,:j,:k))
         end
 
-        @testset "Labels Test" begin
+        @testset "labels" begin
             Q, R = qr(tensor, labels(tensor)[1:2])
             @test labels(Q)[1:2] == labels(tensor)[1:2]
             @test labels(Q)[3] == labels(R)[1]
             @test labels(R)[2] == labels(tensor)[3]
         end
 
-        @testset "Size Test" begin
+        @testset "size" begin
             Q, R = qr(tensor, labels(tensor)[1:2])
             # Q's new index size = min(prod(left_inds), prod(right_inds)).
             @test size(Q) == (2, 2, 4)
@@ -160,7 +162,7 @@
             @test size(R2) == (8, 6, 8)
         end
 
-        @testset "Accuracy Test" begin
+        @testset "[accuracy]" begin
             Q, R = qr(tensor, labels(tensor)[1:2])
             Q_truncated = view(Q, labels(Q)[end] => 1:2)
             tensor_recovered = ein"ijk, kl -> ijl"(Q_truncated, R)

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -126,51 +126,51 @@
                 @test C ≈ C_ein
             end
         end
+    end
 
-        @testset "qr" begin
-            data = rand(2, 2, 2)
-            tensor = Tensor(data, (:i, :j, :k))
+    @testset "qr" begin
+        data = rand(2, 2, 2)
+        tensor = Tensor(data, (:i, :j, :k))
 
-            @testset "Error Handling Test" begin
-                # Throw exception if left_inds is not provided
-                @test_throws ErrorException qr(tensor)
-                # Throw exception if left_inds ∉ labels(tensor)
-                @test_throws ErrorException qr(tensor, (:l,))
-            end
+        @testset "Error Handling Test" begin
+            # Throw exception if left_inds is not provided
+            @test_throws ErrorException qr(tensor)
+            # Throw exception if left_inds ∉ labels(tensor)
+            @test_throws ErrorException qr(tensor, (:l,))
+        end
 
-            @testset "Labels Test" begin
-                Q, R = qr(tensor, labels(tensor)[1:2])
-                @test labels(Q)[1:2] == labels(tensor)[1:2]
-                @test labels(Q)[3] == labels(R)[1]
-                @test labels(R)[2] == labels(tensor)[3]
-            end
+        @testset "Labels Test" begin
+            Q, R = qr(tensor, labels(tensor)[1:2])
+            @test labels(Q)[1:2] == labels(tensor)[1:2]
+            @test labels(Q)[3] == labels(R)[1]
+            @test labels(R)[2] == labels(tensor)[3]
+        end
 
-            @testset "Size Test" begin
-                Q, R = qr(tensor, labels(tensor)[1:2])
-                # Q's new index size = min(prod(left_inds), prod(right_inds)).
-                @test size(Q) == (2, 2, 4)
-                @test size(R) == (2, 2)
+        @testset "Size Test" begin
+            Q, R = qr(tensor, labels(tensor)[1:2])
+            # Q's new index size = min(prod(left_inds), prod(right_inds)).
+            @test size(Q) == (2, 2, 4)
+            @test size(R) == (2, 2)
 
-                # Additional test with different dimensions
-                data2 = rand(2, 4, 6, 8)
-                tensor2 = Tensor(data2, (:i, :j, :k, :l))
-                Q2, R2 = qr(tensor2, labels(tensor2)[1:2])
-                @test size(Q2) == (2, 4, 8)
-                @test size(R2) == (8, 6, 8)
-            end
+            # Additional test with different dimensions
+            data2 = rand(2, 4, 6, 8)
+            tensor2 = Tensor(data2, (:i, :j, :k, :l))
+            Q2, R2 = qr(tensor2, labels(tensor2)[1:2])
+            @test size(Q2) == (2, 4, 8)
+            @test size(R2) == (8, 6, 8)
+        end
 
-            @testset "Accuracy Test" begin
-                Q, R = qr(tensor, labels(tensor)[1:2])
-                Q_truncated = truncatedims(Q, labels(Q)[end], 2)
-                tensor_recovered = ein"ijk, kl -> ijl"(Q_truncated, R)
-                @test tensor_recovered ≈ tensor
+        @testset "Accuracy Test" begin
+            Q, R = qr(tensor, labels(tensor)[1:2])
+            Q_truncated = truncatedims(Q, labels(Q)[end], 2)
+            tensor_recovered = ein"ijk, kl -> ijl"(Q_truncated, R)
+            @test tensor_recovered ≈ tensor
 
-                data2 = rand(2, 4, 6, 8)
-                tensor2 = Tensor(data2, (:i, :j, :k, :l))
-                Q2, R2 = qr(tensor2, labels(tensor2)[1:2])
-                tensor2_recovered = ein"ijk, klm -> ijlm"(Q2, R2)
-                @test tensor2_recovered ≈ tensor2
-            end
+            data2 = rand(2, 4, 6, 8)
+            tensor2 = Tensor(data2, (:i, :j, :k, :l))
+            Q2, R2 = qr(tensor2, labels(tensor2)[1:2])
+            tensor2_recovered = ein"ijk, klm -> ijlm"(Q2, R2)
+            @test tensor2_recovered ≈ tensor2
         end
     end
 

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -126,5 +126,50 @@
                 @test C ≈ C_ein
             end
         end
+
+        @testset "qr" begin
+            data = rand(2, 2, 2)
+            tensor = Tensor(data, (:i, :j, :k))
+
+            @testset "Error Handling Test" begin
+                # Throw exception if left_inds is not provided
+                @test_throws ErrorException qr(tensor)
+                # Throw exception if left_inds ∉ labels(tensor)
+                @test_throws ErrorException qr(tensor, (:l,))
+            end
+
+            @testset "Labels Test" begin
+                Q, R = qr(tensor, labels(tensor)[1:2])
+                @test labels(Q)[1:2] == labels(tensor)[1:2]
+                @test labels(Q)[3] == labels(R)[1]
+                @test labels(R)[2] == labels(tensor)[3]
+            end
+
+            @testset "Size Test" begin
+                Q, R = qr(tensor, labels(tensor)[1:2])
+                # Q's new index size = min(prod(left_inds), prod(right_inds)).
+                @test size(Q) == (2, 2, 4)
+                @test size(R) == (2, 2)
+
+                # Additional test with different dimensions
+                data2 = rand(2, 4, 6, 8)
+                tensor2 = Tensor(data2, (:i, :j, :k, :l))
+                Q2, R2 = qr(tensor2, labels(tensor2)[1:2])
+                @test size(Q2) == (2, 4, 8)
+                @test size(R2) == (8, 6, 8)
+            end
+
+            @testset "Accuracy Test" begin
+                Q, R = qr(tensor, labels(tensor)[1:2])
+                Q_truncated = truncatedims(Q, labels(Q)[end], 2)
+                tensor_recovered = ein"ijk, kl -> ijl"(Q_truncated, R)
+                @test tensor_recovered ≈ tensor
+
+                data2 = rand(2, 4, 6, 8)
+                tensor2 = Tensor(data2, (:i, :j, :k, :l))
+                Q2, R2 = qr(tensor2, labels(tensor2)[1:2])
+                tensor2_recovered = ein"ijk, klm -> ijlm"(Q2, R2)
+                @test tensor2_recovered ≈ tensor2
+            end
     end
 end

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -171,5 +171,6 @@
                 tensor2_recovered = ein"ijk, klm -> ijlm"(Q2, R2)
                 @test tensor2_recovered ≈ tensor2
             end
+        end
     end
 end

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -175,4 +175,53 @@
             @test tensor2_recovered ≈ tensor2
         end
     end
+
+    @testset "lu" begin
+        data = rand(2, 2, 2)
+        tensor = Tensor(data, (:i, :j, :k))
+
+        @testset "[exceptions]" begin
+            # Throw exception if left_inds is not provided
+            @test_throws ErrorException lu(tensor)
+            # Throw exception if left_inds ∉ labels(tensor)
+            @test_throws ErrorException lu(tensor, (:l,))
+            # throw exception if no right-inds
+            @test_throws ErrorException lu(tensor, (:i,:j,:k))
+        end
+
+        @testset "labels" begin
+            P, L, U = lu(tensor, labels(tensor)[1:2])
+            @test labels(P)[1:2] == labels(tensor)[1:2]
+            @test labels(P)[3:4] == labels(L)[1:2]
+            @test labels(L)[3] == labels(U)[1]
+            @test labels(U)[2] == labels(tensor)[3]
+        end
+
+        @testset "size" begin
+            P, L, U = lu(tensor, labels(tensor)[1:2])
+            @test size(P) == (2, 2, 2, 2)
+            @test size(L) == (2, 2, 2)
+            @test size(U) == (2, 2)
+
+            # Additional test with different dimensions
+            data2 = rand(2, 4, 6, 8)
+            tensor2 = Tensor(data2, (:i, :j, :k, :l))
+            P2, L2, U2 = lu(tensor2, labels(tensor2)[1:2])
+            @test size(P2) == (2, 4, 2, 4)
+            @test size(L2) == (2, 4, 8)
+            @test size(U2) == (8, 6, 8)
+        end
+
+        @testset "[accuracy]" begin
+            P, L, U = lu(tensor, labels(tensor)[1:2])
+            tensor_recovered = contract(contract(P, L), U)
+            @test tensor_recovered ≈ tensor
+
+            data2 = rand(2, 4, 6, 8)
+            tensor2 = Tensor(data2, (:i, :j, :k, :l))
+            P2, L2, U2 = lu(tensor2, labels(tensor2)[1:2])
+            tensor2_recovered = contract(contract(P2, L2), U2)
+            @test tensor2_recovered ≈ tensor2
+        end
+    end
 end

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -171,6 +171,7 @@
                 tensor2_recovered = ein"ijk, klm -> ijlm"(Q2, R2)
                 @test tensor2_recovered ≈ tensor2
             end
+        end
     end
 
     @testset "qr" begin

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -126,6 +126,51 @@
                 @test C ≈ C_ein
             end
         end
+
+        @testset "qr" begin
+            data = rand(2, 2, 2)
+            tensor = Tensor(data, (:i, :j, :k))
+
+            @testset "Error Handling Test" begin
+                # Throw exception if left_inds is not provided
+                @test_throws ErrorException qr(tensor)
+                # Throw exception if left_inds ∉ labels(tensor)
+                @test_throws ErrorException qr(tensor, (:l,))
+            end
+
+            @testset "Labels Test" begin
+                Q, R = qr(tensor, labels(tensor)[1:2])
+                @test labels(Q)[1:2] == labels(tensor)[1:2]
+                @test labels(Q)[3] == labels(R)[1]
+                @test labels(R)[2] == labels(tensor)[3]
+            end
+
+            @testset "Size Test" begin
+                Q, R = qr(tensor, labels(tensor)[1:2])
+                # Q's new index size = min(prod(left_inds), prod(right_inds)).
+                @test size(Q) == (2, 2, 4)
+                @test size(R) == (2, 2)
+
+                # Additional test with different dimensions
+                data2 = rand(2, 4, 6, 8)
+                tensor2 = Tensor(data2, (:i, :j, :k, :l))
+                Q2, R2 = qr(tensor2, labels(tensor2)[1:2])
+                @test size(Q2) == (2, 4, 8)
+                @test size(R2) == (8, 6, 8)
+            end
+
+            @testset "Accuracy Test" begin
+                Q, R = qr(tensor, labels(tensor)[1:2])
+                Q_truncated = truncatedims(Q, labels(Q)[end], 2)
+                tensor_recovered = ein"ijk, kl -> ijl"(Q_truncated, R)
+                @test tensor_recovered ≈ tensor
+
+                data2 = rand(2, 4, 6, 8)
+                tensor2 = Tensor(data2, (:i, :j, :k, :l))
+                Q2, R2 = qr(tensor2, labels(tensor2)[1:2])
+                tensor2_recovered = ein"ijk, klm -> ijlm"(Q2, R2)
+                @test tensor2_recovered ≈ tensor2
+            end
     end
 
     @testset "qr" begin

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -126,51 +126,51 @@
                 @test C ≈ C_ein
             end
         end
+    end
 
-        @testset "qr" begin
-            data = rand(2, 2, 2)
-            tensor = Tensor(data, (:i, :j, :k))
+    @testset "qr" begin
+        data = rand(2, 2, 2)
+        tensor = Tensor(data, (:i, :j, :k))
 
-            @testset "Error Handling Test" begin
-                # Throw exception if left_inds is not provided
-                @test_throws ErrorException qr(tensor)
-                # Throw exception if left_inds ∉ labels(tensor)
-                @test_throws ErrorException qr(tensor, (:l,))
-            end
+        @testset "Error Handling Test" begin
+            # Throw exception if left_inds is not provided
+            @test_throws ErrorException qr(tensor)
+            # Throw exception if left_inds ∉ labels(tensor)
+            @test_throws ErrorException qr(tensor, (:l,))
+        end
 
-            @testset "Labels Test" begin
-                Q, R = qr(tensor, labels(tensor)[1:2])
-                @test labels(Q)[1:2] == labels(tensor)[1:2]
-                @test labels(Q)[3] == labels(R)[1]
-                @test labels(R)[2] == labels(tensor)[3]
-            end
+        @testset "Labels Test" begin
+            Q, R = qr(tensor, labels(tensor)[1:2])
+            @test labels(Q)[1:2] == labels(tensor)[1:2]
+            @test labels(Q)[3] == labels(R)[1]
+            @test labels(R)[2] == labels(tensor)[3]
+        end
 
-            @testset "Size Test" begin
-                Q, R = qr(tensor, labels(tensor)[1:2])
-                # Q's new index size = min(prod(left_inds), prod(right_inds)).
-                @test size(Q) == (2, 2, 4)
-                @test size(R) == (2, 2)
+        @testset "Size Test" begin
+            Q, R = qr(tensor, labels(tensor)[1:2])
+            # Q's new index size = min(prod(left_inds), prod(right_inds)).
+            @test size(Q) == (2, 2, 4)
+            @test size(R) == (2, 2)
 
-                # Additional test with different dimensions
-                data2 = rand(2, 4, 6, 8)
-                tensor2 = Tensor(data2, (:i, :j, :k, :l))
-                Q2, R2 = qr(tensor2, labels(tensor2)[1:2])
-                @test size(Q2) == (2, 4, 8)
-                @test size(R2) == (8, 6, 8)
-            end
+            # Additional test with different dimensions
+            data2 = rand(2, 4, 6, 8)
+            tensor2 = Tensor(data2, (:i, :j, :k, :l))
+            Q2, R2 = qr(tensor2, labels(tensor2)[1:2])
+            @test size(Q2) == (2, 4, 8)
+            @test size(R2) == (8, 6, 8)
+        end
 
-            @testset "Accuracy Test" begin
-                Q, R = qr(tensor, labels(tensor)[1:2])
-                Q_truncated = truncatedims(Q, labels(Q)[end], 2)
-                tensor_recovered = ein"ijk, kl -> ijl"(Q_truncated, R)
-                @test tensor_recovered ≈ tensor
+        @testset "Accuracy Test" begin
+            Q, R = qr(tensor, labels(tensor)[1:2])
+            Q_truncated = truncatedims(Q, labels(Q)[end], 2)
+            tensor_recovered = ein"ijk, kl -> ijl"(Q_truncated, R)
+            @test tensor_recovered ≈ tensor
 
-                data2 = rand(2, 4, 6, 8)
-                tensor2 = Tensor(data2, (:i, :j, :k, :l))
-                Q2, R2 = qr(tensor2, labels(tensor2)[1:2])
-                tensor2_recovered = ein"ijk, klm -> ijlm"(Q2, R2)
-                @test tensor2_recovered ≈ tensor2
-            end
+            data2 = rand(2, 4, 6, 8)
+            tensor2 = Tensor(data2, (:i, :j, :k, :l))
+            Q2, R2 = qr(tensor2, labels(tensor2)[1:2])
+            tensor2_recovered = ein"ijk, klm -> ijlm"(Q2, R2)
+            @test tensor2_recovered ≈ tensor2
         end
     end
 end

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -132,21 +132,23 @@
         data = rand(2, 2, 2)
         tensor = Tensor(data, (:i, :j, :k))
 
-        @testset "Error Handling Test" begin
+        @testset "[exceptions]" begin
             # Throw exception if left_inds is not provided
             @test_throws ErrorException qr(tensor)
             # Throw exception if left_inds ∉ labels(tensor)
             @test_throws ErrorException qr(tensor, (:l,))
+            # throw exception if no right-inds
+            @test_throws ErrorException qr(tensor, (:i,:j,:k))
         end
 
-        @testset "Labels Test" begin
+        @testset "labels" begin
             Q, R = qr(tensor, labels(tensor)[1:2])
             @test labels(Q)[1:2] == labels(tensor)[1:2]
             @test labels(Q)[3] == labels(R)[1]
             @test labels(R)[2] == labels(tensor)[3]
         end
 
-        @testset "Size Test" begin
+        @testset "size" begin
             Q, R = qr(tensor, labels(tensor)[1:2])
             # Q's new index size = min(prod(left_inds), prod(right_inds)).
             @test size(Q) == (2, 2, 4)
@@ -160,7 +162,7 @@
             @test size(R2) == (8, 6, 8)
         end
 
-        @testset "Accuracy Test" begin
+        @testset "[accuracy]" begin
             Q, R = qr(tensor, labels(tensor)[1:2])
             Q_truncated = truncatedims(Q, labels(Q)[end], 2)
             tensor_recovered = ein"ijk, kl -> ijl"(Q_truncated, R)

--- a/test/Tensor_test.jl
+++ b/test/Tensor_test.jl
@@ -13,6 +13,8 @@
 
             @test labels(tensor) == (:i, :j, :k)
             @test parent(tensor) === data
+
+            @test_throws DimensionMismatch Tensor(zeros(2, 3), (:i, :i))
         end
     end
 


### PR DESCRIPTION
### Summary
This PR adds a new `lu` function for tensors, extending the `LinearAlgebra.lu` function. The new `lu` function returns the LU decomposition of a `Tensor`, where the tensor can be recovered by contracting the permutation tensor `P`, the tensor `L`, and tensor `U`. The tensors `L` and `U` are reshaped versions of the original lower and upper triangular matrices obtained during the decomposition process, respectively.

This implementation is inspired by the LU decomposition in the `scipy` library, as it returns the permutation tensor `P` allowing the original tensor to be recovered with the contraction `P * L * U`. This contrasts with `LinearAlgebra`, where the permutation vector `p` is returned, and the original matrix can be recovered with `P' * A = L * U` (where `P'` is the permutation matrix built from `p`).

Please let me know if there are any concerns or issues with extending the `LinearAlgebra` library in this manner.

We have also added tests for this new function.

### Example
A usage example of the `lu` function:
```julia
julia> using Tenet; using LinearAlgebra; using Test

julia> tensor = Tensor(rand(4, 4, 4), (:i, :j, :k))
4×4×4 Tensor{Float64, 3, Array{Float64, 3}}:
...

julia> P, L, U = lu(tensor, left_inds = labels(tensor)[1:2])
...

julia> @test contract(contract(P, L), U) ≈ tensor
Test Passed
```