### PR TITLE
Add `lu` decomposition for `Tensor`s

### DIFF
--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -100,3 +100,39 @@ function LinearAlgebra.qr(t::Tensor, left_inds; kwargs...)
 
     return Q, R
 end
+
+LinearAlgebra.lu(t::Tensor; left_inds=(), kwargs...) = lu(t, left_inds; kwargs...)
+
+function LinearAlgebra.lu(t::Tensor, left_inds; kwargs...)
+   # TODO better error exception and checks
+   isempty(left_inds) && throw(ErrorException("no left-indices in LU factorization"))
+   left_inds ⊆ labels(t) || throw(ErrorException("all left-indices must be in $(labels(t))"))
+
+   right_inds = setdiff(labels(t), left_inds)
+   isempty(right_inds) && throw(ErrorException("no right-indices in LU factorization"))
+
+   # permute array
+   tensor = permutedims(t, (left_inds..., right_inds...))
+   data = reshape(parent(tensor), prod(i -> size(t, i), left_inds), prod(i -> size(t, i), right_inds))
+
+   # compute LU
+   L, U, p = lu(data; kwargs...)
+
+   # build permutation matrix
+   P = Matrix{eltype(data)}(I, size(L, 1), size(L, 1))
+   P = P[invperm(p), :]
+
+   # tensorify results
+   L = reshape(L, ([size(t, ind) for ind in left_inds]..., size(L, 2)))
+   U = reshape(U, (size(U, 1), [size(t, ind) for ind in right_inds]...))
+   P = reshape(P, (append!([size(t, ind) for ind in left_inds], [size(t, ind) for ind in left_inds])...))
+
+   shared_inds_PL = (Symbol(uuid4()), Symbol(uuid4()))
+   shared_inds_LU = Symbol(uuid4())
+
+   P = Tensor(P, (left_inds..., shared_inds_PL...))
+   L = Tensor(L, (shared_inds_PL..., shared_inds_LU))
+   U = Tensor(U, (shared_inds_LU, right_inds...))
+
+   return P, L, U
+end

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -175,4 +175,53 @@
             @test tensor2_recovered ≈ tensor2
         end
     end
+
+    @testset "lu" begin
+        data = rand(2, 2, 2)
+        tensor = Tensor(data, (:i, :j, :k))
+
+        @testset "[exceptions]" begin
+            # Throw exception if left_inds is not provided
+            @test_throws ErrorException lu(tensor)
+            # Throw exception if left_inds ∉ labels(tensor)
+            @test_throws ErrorException lu(tensor, (:l,))
+            # throw exception if no right-inds
+            @test_throws ErrorException lu(tensor, (:i,:j,:k))
+        end
+
+        @testset "labels" begin
+            P, L, U = lu(tensor, labels(tensor)[1:2])
+            @test labels(P)[1:2] == labels(tensor)[1:2]
+            @test labels(P)[3:4] == labels(L)[1:2]
+            @test labels(L)[3] == labels(U)[1]
+            @test labels(U)[2] == labels(tensor)[3]
+        end
+
+        @testset "size" begin
+            P, L, U = lu(tensor, labels(tensor)[1:2])
+            @test size(P) == (2, 2, 2, 2)
+            @test size(L) == (2, 2, 2)
+            @test size(U) == (2, 2)
+
+            # Additional test with different dimensions
+            data2 = rand(2, 4, 6, 8)
+            tensor2 = Tensor(data2, (:i, :j, :k, :l))
+            P2, L2, U2 = lu(tensor2, labels(tensor2)[1:2])
+            @test size(P2) == (2, 4, 2, 4)
+            @test size(L2) == (2, 4, 8)
+            @test size(U2) == (8, 6, 8)
+        end
+
+        @testset "[accuracy]" begin
+            P, L, U = lu(tensor, labels(tensor)[1:2])
+            tensor_recovered = contract(contract(P, L), U)
+            @test tensor_recovered ≈ tensor
+
+            data2 = rand(2, 4, 6, 8)
+            tensor2 = Tensor(data2, (:i, :j, :k, :l))
+            P2, L2, U2 = lu(tensor2, labels(tensor2)[1:2])
+            tensor2_recovered = contract(contract(P2, L2), U2)
+            @test tensor2_recovered ≈ tensor2
+        end
+    end
 end


### PR DESCRIPTION
### Summary
This PR adds a new `lu` function for tensors, extending the `LinearAlgebra.lu` function (resolve #3). The new `lu` function returns the LU decomposition of a `Tensor`, where the tensor can be recovered by contracting the permutation tensor `P`, the tensor `L`, and tensor `U`. The tensors `L` and `U` are reshaped versions of the original lower and upper triangular matrices obtained during the decomposition process, respectively.

This implementation is inspired by the LU decomposition in the `scipy` library, as it returns the permutation tensor `P` allowing the original tensor `A` to be recovered with the contraction `A = P * L * U`. This contrasts with `LinearAlgebra`, where the permutation vector `p` is returned, and the original matrix can be recovered with `P' * A = L * U` (where `P'` is the permutation matrix built from `p`).

Please let me know if there are any concerns or issues with extending the `LinearAlgebra` library in this manner.

We have also added tests for this new function.

### Example
A usage example of the `lu` function:
```julia
julia> using Tenet; using LinearAlgebra; using Test

julia> tensor = Tensor(rand(4, 4, 4), (:i, :j, :k))
4×4×4 Tensor{Float64, 3, Array{Float64, 3}}:
...

julia> P, L, U = lu(tensor, left_inds = labels(tensor)[1:2])
...

julia> @test contract(contract(P, L), U) ≈ tensor
Test Passed
```
