### PR TITLE
Enhance `copy` method to support `Tensor{SubArray}` type

### DIFF
--- a/src/Tensor.jl
+++ b/src/Tensor.jl
@@ -40,9 +40,9 @@ Tensor(data::Number; meta...) = Tensor(fill(data); meta...)
 
 Base.copy(t::Tensor) = Tensor(parent(t), labels(t); deepcopy(t.meta)...)
 
-function Base.copy(t::Tensor{T,N,SubArray{T,N,Array{T,M},I,L}}) where {T, N, M, I, L}
-    data = copy(t.data)  # This calls copy(::SubArray)
-    labels = t.labels  # Tuples are immutable, no need to copy
+function Base.copy(t::Tensor{T,N,<:SubArray{T,N}}) where {T, N}
+    data = copy(t.data)
+    labels = t.labels
     meta = deepcopy(t.meta)
     return Tensor(data, labels; (k => v for (k, v) in meta)...)
 end

--- a/src/Tensor.jl
+++ b/src/Tensor.jl
@@ -40,6 +40,13 @@ Tensor(data::Number; meta...) = Tensor(fill(data); meta...)
 
 Base.copy(t::Tensor) = Tensor(parent(t), labels(t); deepcopy(t.meta)...)
 
+function Base.copy(t::Tensor{T,N,SubArray{T,M,Array{T,M},I,L}}) where {T, N, M, I, L}
+    data = copy(t.data)  # This calls copy(::SubArray)
+    labels = t.labels  # Tuples are immutable, no need to copy
+    meta = deepcopy(t.meta)
+    return Tensor(data, labels; (k => v for (k, v) in meta)...)
+end
+
 # TODO pass new labels and meta
 function Base.similar(t::Tensor{_,N}, ::Type{T}; kwargs...) where {_,T,N}
     if N == 0

--- a/src/Tensor.jl
+++ b/src/Tensor.jl
@@ -40,7 +40,7 @@ Tensor(data::Number; meta...) = Tensor(fill(data); meta...)
 
 Base.copy(t::Tensor) = Tensor(parent(t), labels(t); deepcopy(t.meta)...)
 
-function Base.copy(t::Tensor{T,N,SubArray{T,M,Array{T,M},I,L}}) where {T, N, M, I, L}
+function Base.copy(t::Tensor{T,N,SubArray{T,N,Array{T,M},I,L}}) where {T, N, M, I, L}
     data = copy(t.data)  # This calls copy(::SubArray)
     labels = t.labels  # Tuples are immutable, no need to copy
     meta = deepcopy(t.meta)

--- a/test/Tensor_test.jl
+++ b/test/Tensor_test.jl
@@ -26,6 +26,9 @@
         @test labels(tensor) === labels(copy(tensor))
         @test tensor.meta == copy(tensor).meta
         @test tensor.meta !== copy(tensor).meta
+
+        @test copy(view(tensor, :i => 1)) isa Tensor
+        @test parent(copy(view(tensor, :i => 1))) isa Array
     end
 
     @testset "isequal" begin


### PR DESCRIPTION
### Summary
This PR addresses issue #24, where it was identified that calling `copy` on a `Tensor` object containing a `SubArray` did not actually `copy` the `SubArray`, resulting in potential memory issues.

To resolve this, I have extended the `copy` method to handle `Tensor{SubArray}` objects specifically. This enhanced `copy` method creates a completely independent `Tensor` object by copying all `data`, `labels`, and `metadata` from the original `Tensor`. This ensures that the copied `Tensor` is fully independent of the original.

In addition to these changes, I've also updated and expanded our "copy" `testset` to validate the correct functionality of this enhanced `copy` method.

### Example
Demonstration of the new `copy(Tensor{SubArray})` function:
```julia
julia> using Tensors

julia> A = Tensor(rand(2, 4, 2), (:i, :j, :k))
2×4×2 Tensor{Float64, 3, Array{Float64, 3}}:
[:, :, 1] =
 0.781493   0.659441  0.51292   0.00560809
 0.0561432  0.712748  0.440209  0.709937

[:, :, 2] =
 0.104424  0.987029  0.156034  0.419862
 0.5323    0.746824  0.733173  0.0647962

julia> B = view(A, :j => 1)
2×2 Tensor{Float64, 2, SubArray{Float64, 2, Array{Float64, 3}, Tuple{Base.Slice{Base.OneTo{Int64}}, Int64, Base.Slice{Base.OneTo{Int64}}}, false}}:
 0.781493   0.104424
 0.0561432  0.5323

julia> copy(B)
2×2 Tensor{Float64, 2, Matrix{Float64}}:
 0.781493   0.104424
 0.0561432  0.5323
```