### PR TITLE
Enhance `contract` to support multiple input `Tensor`s

### DIFF
--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -63,6 +63,7 @@ contract(a::Tensor{T}, b::Union{T,AbstractArray{T,0}}) where {T} = contract(a, T
 contract(a::AbstractArray{<:Any,0}, b::AbstractArray{<:Any,0}) =
     contract(Tensor(a), Tensor(b)) |> only
 contract(a::Number, b::Number) = contract(fill(a), fill(b))
+contract(tensors::AbstractArray{<:Tensor}) = reduce(contract, tensors)
 
 """
     *(::Tensor, ::Tensor)

--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -63,7 +63,7 @@ contract(a::Tensor{T}, b::Union{T,AbstractArray{T,0}}) where {T} = contract(a, T
 contract(a::AbstractArray{<:Any,0}, b::AbstractArray{<:Any,0}) =
     contract(Tensor(a), Tensor(b)) |> only
 contract(a::Number, b::Number) = contract(fill(a), fill(b))
-contract(tensors::AbstractArray{<:Tensor}) = reduce(contract, tensors)
+contract(tensors::Tensor...) = reduce(contract, tensors)
 
 """
     *(::Tensor, ::Tensor)

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -156,6 +156,18 @@
                 @test parent(C) ≈ C_ein
             end
         end
+
+        @testset "multiple tensors" begin
+            A = Tensor(rand(2, 3, 4), (:i, :j, :k))
+            B = Tensor(rand(4, 5, 3), (:k, :l, :j))
+            C = Tensor(rand(5, 6, 2), (:l, :m, :i))
+            D = Tensor(rand(6, 7, 2), (:m, :n, :i))
+
+            contracted = contract(A, B, C, D)
+            @test issetequal(labels(contracted), (:n, :i))
+            @test issetequal(size(contracted), (7, 2))
+            @test contracted ≈ contract(contract(contract(A, B), C), D)
+        end
     end
 
     @testset "qr" begin


### PR DESCRIPTION
This PR enhances the `contract` function for multiple tensors, which resolves [issue #16 in EinExprs](https://github.com/bsc-quantic/EinExprs.jl/issues/16). The function utilizes `reduce` to perform pairwise `Tensor` contractions.
To ensure the robustness of these changes we added a `testset` that covers the new `contract` functionality, checking its behavior with various tensors in inputs.