### PR TITLE
Enhance `contract` to support keyword arguments during reduction

### DIFF
--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -62,7 +62,7 @@ contract(a::Union{T,AbstractArray{T,0}}, b::Tensor{T}) where {T} = contract(Tens
 contract(a::Tensor{T}, b::Union{T,AbstractArray{T,0}}) where {T} = contract(a, Tensor(b))
 contract(a::AbstractArray{<:Any,0}, b::AbstractArray{<:Any,0}) = contract(Tensor(a), Tensor(b)) |> only
 contract(a::Number, b::Number) = contract(fill(a), fill(b))
-contract(tensors::Tensor...) = reduce(contract, tensors)
+contract(tensors::Tensor...; kwargs...) = reduce(((x, y) -> contract(x, y; kwargs...)), tensors)
 
 """
     *(::Tensor, ::Tensor)

--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -62,7 +62,7 @@ contract(a::Union{T,AbstractArray{T,0}}, b::Tensor{T}) where {T} = contract(Tens
 contract(a::Tensor{T}, b::Union{T,AbstractArray{T,0}}) where {T} = contract(a, Tensor(b))
 contract(a::AbstractArray{<:Any,0}, b::AbstractArray{<:Any,0}) = contract(Tensor(a), Tensor(b)) |> only
 contract(a::Number, b::Number) = contract(fill(a), fill(b))
-contract(tensors::Tensor...; kwargs...) = reduce(((x, y) -> contract(x, y; kwargs...)), tensors)
+contract(tensors::Tensor...; kwargs...) = reduce((x, y) -> contract(x, y; kwargs...), tensors)
 
 """
     *(::Tensor, ::Tensor)


### PR DESCRIPTION
### Summary
Following from the PR #31, this PR modifies the `contract(tensors...)` function to support `kwargs`, therefore allowing them to be passed to the `contract(tensor1, tensor2)` function.

This change is useful since `Tenet.contract(expr::EinExpr)` calls the `contract` method with the `dims` keyword argument, leading to an error due to the absence of handling `kwargs` in the `contract(tensors...)` function.

With this update, the `dims` argument (as well as other potential keyword arguments) can be appropriately handled during the tensor contraction process.